### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ configuration options as the second argument.
       ...> |> Map.put(:body, username: "person@mymetabase.com", password: "fakepassword")
       ...> |> Map.put(:method, :post)
       ...> |> Map.put(:path, "/session")
-      ...> |> Metabase.send(host: "mymetabase.com/api")
+      ...> |> Metabase.send(host: "mymetabase.com/")
       {:ok, %Metabase.Response{}}
 
 ## Configuration


### PR DESCRIPTION
The metabase url should not have "api" in it because "api" is added elsewhere.